### PR TITLE
Added apache2 configurations

### DIFF
--- a/apache-conf/sc2.conf
+++ b/apache-conf/sc2.conf
@@ -1,0 +1,23 @@
+# Apache configuration for sc2reporter
+# It will redirect localhost to your application port.
+# For example, if your application is running on port 8000, 3000, 8081 and you want to access it on port 80
+# you should use the following configuration:
+<Proxy *>
+    Order deny,allow
+    Allow from all
+</Proxy>
+# Fastapi backend, change port and /api to your desired path which matches ROOT_PATH in docker-compose.yml
+<Location /api/>
+    ProxyPass http://localhost:8000/
+    ProxyPassReverse http://localhost:8000/
+</Location>
+# React frontend, change port and /frontend to your desired path
+<Location /frontend>
+    ProxyPass http://localhost:3000/
+    ProxyPassReverse http://localhost:3000/
+</Location>
+# Mongo express, change mongo-express to your desired path
+<Location /mongo-express>
+    ProxyPass http://localhost:8081/mongo-express
+    ProxyPassReverse http://localhost:8081/mongo-express
+</Location>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
     environment:
     - ME_CONFIG_MONGODB_SERVER=mongodb
     - ME_CONFIG_MONGODB_PORT=27017
+    - ME_CONFIG_SITE_BASEURL=/mongo-express
     depends_on:
       - mongodb
 


### PR DESCRIPTION
The file sets up a proxy that redirects traffic from the Apache server to the local host on specified ports. The code includes three locations, /api, /frontend, and /mongo-express, which correspond to different paths on the server and are redirected to different ports on the local host. 
For example, traffic to the /frontend path on the Apache server will be redirected to the local host on port 3000. 



