### PR TITLE
Revert "Prefix url"

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -25,7 +25,6 @@ jobs:
         run: yarn build
         env:
           REACT_APP_BACKEND_URL: ${{ secrets.REACT_APP_BACKEND_URL }}
-          PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/firebase-hosting-pull_request.yml
+++ b/.github/workflows/firebase-hosting-pull_request.yml
@@ -25,7 +25,6 @@ jobs:
         run: yarn build
         env:
           REACT_APP_BACKEND_URL: ${{ secrets.REACT_APP_BACKEND_URL }}
-          PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,6 @@ services:
       - '3000:3000'
     environment:
       - 'REACT_APP_BACKEND_URL=http://0.0.0.0:8000'
-      - 'PUBLIC_URL=v1'
     depends_on:
       - fastapi
   grapetree:

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -6,10 +6,9 @@ import { App } from './App'
 import { BrowserRouter } from 'react-router-dom'
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
-const { PUBLIC_URL } = process.env
 root.render(
   <React.StrictMode>
-    <BrowserRouter basename={PUBLIC_URL}>
+    <BrowserRouter>
       <App />
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
Reverts genomic-medicine-sweden/docker-sc2reporter#98
The prefix URL is only working locally. After merging changes, the app stopped working. Even when I made changes to fix it (removing the prefix as an environment variable and using a string), the Firebase link for the pull request will not work unless we manually add it, which is not a good solution during the development.