### PR TITLE
Fix phylogeny delete sample

### DIFF
--- a/frontend/src/components/SamplesTable.tsx
+++ b/frontend/src/components/SamplesTable.tsx
@@ -28,7 +28,7 @@ export const SamplesTable = ({
   const rowSelection = {
     onChange: (selectedRowKeys) => {
       setSelectedRowKeys(selectedRowKeys)
-      const selectedSamplesIds = selectedRowKeys.map((item) => `&sample_ids=${item}`).join('')
+      const selectedSamplesIds = selectedRowKeys.map((item) => `sample_id=${item}`).join('&')
       setSamplesId(selectedSamplesIds)
     },
     selectedRowKeys,
@@ -65,6 +65,7 @@ export const SamplesTable = ({
     if (selectedRowKeys.length > 2) {
       getPhylogeny(token, group, samplesId).then((response) => {
         setCopiedText(JSON.stringify(response))
+        console.log(response)
         if (response != '') {
           showModal()
           navigator.clipboard.writeText(JSON.stringify(response))

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -242,7 +242,7 @@ export const deleteUser = async (token, username): Promise<any> => {
 }
 
 export const getPhylogeny = async (token, group, samples): Promise<any> => {
-  const endPoint = `${REACT_APP_BACKEND_URL}/phyllogeny/?group=${group}&${samples}`
+  const endPoint = `${REACT_APP_BACKEND_URL}/phylogeny/?group=${group}&${samples}`
   return new Promise((resolve, reject) => {
     axios
       .get(endPoint, {


### PR DESCRIPTION
The modification of variable names in the backend caused both the sample deletion and Phylogeny retrieval functions to break.